### PR TITLE
fix: implement focusIndex parameter across all packages

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -94,6 +94,7 @@ export function useMeetGrid(options: MeetGridOptions): MeetGridResult {
         options.aspectRatio,
         options.gap,
         options.layoutMode,
+        options.focusIndex,
         options.pinnedIndex,
         options.speakerIndex,
         options.sidebarPosition,


### PR DESCRIPTION
- Core: Add focusIndex to MeetGridOptions and map to internal params
- React: Add focusIndex to useMeetGrid dependency array
- Vue: No changes needed (auto-tracked by computed)
- Maintain backward compatibility with nullish coalescing